### PR TITLE
fixups

### DIFF
--- a/projects/02/main.cpp
+++ b/projects/02/main.cpp
@@ -1,7 +1,9 @@
 #include "utils.h"
 
+#include <vector>
 #include <iostream>
 #include <algorithm>
+#include <exception>
 
 using namespace std;
 
@@ -15,14 +17,16 @@ int main(int, char **) {
 			break;
 		}
 
-		addresses.push_back(parseIPAddress(line));
+		try {
+			addresses.push_back(parseIPAddress(line));
+		} catch(exception& e) {
+			cerr << e.what() << ": " << line << endl;
+			return -1;
+		}
 	}
 
 	sort(addresses.begin(), addresses.end(), [](const IPAddress& a, const IPAddress& b) {
-		return a[0] > b[0]
-			|| a[0] == b[0] && a[1] > b[1]
-			|| a[0] == b[0] && a[1] == b[1] && a[2] > b[2]
-			|| a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] > b[3];
+		return toUInt32(a) > toUInt32(b);
 	});
 
 	for (auto addr: addresses)

--- a/projects/02/utils.cpp
+++ b/projects/02/utils.cpp
@@ -2,7 +2,7 @@
 #include <regex>
 #include <stdexcept>
 #include <algorithm>
-#include  <sstream>
+#include <sstream>
 
 using namespace std;
 
@@ -11,20 +11,24 @@ IPAddress parseIPAddress(const string& str) {
     smatch match;
 
     if (!regex_match(str, match, re)) {
-        throw logic_error("Not an IP address string: " + str);
+        throw logic_error("Not an IP address string");
     }
 
-    IPAddress result;
-    transform(++match.begin(), match.end(), back_inserter(result), [&str](const string& piece) {
+    const auto getByte = [](const string& piece) -> uint8_t {
         const auto byte = stoul(piece);
         if (byte > 255) {
-            throw logic_error("Not an IP address string: " + str);
+            throw logic_error("Not an IP address string");
         }
 
         return byte;
-    });
+    };
 
-    return result;
+    return {
+        getByte(match[1]),
+        getByte(match[2]),
+        getByte(match[3]),
+        getByte(match[4])
+    };
 };
 
 string toString(const IPAddress& ip) {
@@ -33,4 +37,8 @@ string toString(const IPAddress& ip) {
     s << to_string(ip[0]) << "." << to_string(ip[1]) << "." << to_string(ip[2]) << "." << to_string(ip[3]);
 
     return s.str();
+}
+
+uint32_t toUInt32(const IPAddress& ip) {
+    return (ip[0] << 24) | (ip[1] << 16) | (ip[2] << 8) | ip[3];
 }

--- a/projects/02/utils.h
+++ b/projects/02/utils.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <vector>
+#include <array>
 #include <cstdint>
 #include <string>
 
-using IPAddress = std::vector<uint8_t>;
+using IPAddress = std::array<uint8_t, 4>;
 
 IPAddress parseIPAddress(const std::string& str);
 std::string toString(const IPAddress& ipAddress);
+uint32_t toUInt32(const IPAddress& ipAddress);

--- a/projects/02/utils_test.cc
+++ b/projects/02/utils_test.cc
@@ -3,14 +3,14 @@
 #include <gtest/gtest.h>
 
 TEST(parseIPAddress, ValidAddress) {
-  EXPECT_EQ(parseIPAddress("0.0.0.0"), std::vector<uint8_t>({0, 0, 0, 0}));
-  EXPECT_EQ(parseIPAddress("127.0.0.1"), std::vector<uint8_t>({127, 0, 0, 1}));
-  EXPECT_EQ(parseIPAddress("255.255.255.255"), std::vector<uint8_t>({255, 255, 255, 255}));
+  EXPECT_EQ(parseIPAddress("0.0.0.0"), IPAddress({0, 0, 0, 0}));
+  EXPECT_EQ(parseIPAddress("127.0.0.1"), IPAddress({127, 0, 0, 1}));
+  EXPECT_EQ(parseIPAddress("255.255.255.255"), IPAddress({255, 255, 255, 255}));
 
-  EXPECT_EQ(parseIPAddress("127.0.0.1 "), std::vector<uint8_t>({127, 0, 0, 1}));
-  EXPECT_EQ(parseIPAddress("127.0.0.1\t"), std::vector<uint8_t>({127, 0, 0, 1}));
-  EXPECT_EQ(parseIPAddress("127.0.0.1 foo bar"), std::vector<uint8_t>({127, 0, 0, 1}));
-  EXPECT_EQ(parseIPAddress("127.0.0.1\tfoo\tbar"), std::vector<uint8_t>({127, 0, 0, 1}));
+  EXPECT_EQ(parseIPAddress("127.0.0.1 "), IPAddress({127, 0, 0, 1}));
+  EXPECT_EQ(parseIPAddress("127.0.0.1\t"), IPAddress({127, 0, 0, 1}));
+  EXPECT_EQ(parseIPAddress("127.0.0.1 foo bar"), IPAddress({127, 0, 0, 1}));
+  EXPECT_EQ(parseIPAddress("127.0.0.1\tfoo\tbar"), IPAddress({127, 0, 0, 1}));
 }
 
 TEST(parseIPAddress, InvalidAddress) {
@@ -34,4 +34,10 @@ TEST(parseIPAddress, InvalidAddress) {
 
 TEST(toString, ValidAddress) {
   EXPECT_EQ(toString({127, 0, 0, 1}), "127.0.0.1");
+}
+
+TEST(toUint32, Simple) {
+  EXPECT_EQ(toUInt32({0, 0, 0, 0}), 0);
+  EXPECT_EQ(toUInt32({127, 0, 0, 1}), 0x7F000001);
+  EXPECT_EQ(toUInt32({255, 255, 255, 255}), 0xFFFFFFFF);
 }


### PR DESCRIPTION
- используем std::array<uint8_t, 4> вместо std::vector<uint8_t> для IPAddress
- приводим IPAddress к uint32_t для сравнения вместо сравнения отдельных октетов
- error handling